### PR TITLE
Adds envelopes into the schema again

### DIFF
--- a/schema.csql
+++ b/schema.csql
@@ -23,3 +23,12 @@ CREATE TABLE effective (
   party text,
   rule_id text,
   PRIMARY KEY (rule_id));
+
+CREATE TABLE envelopes (
+  document_id text,
+  party text,
+  country text,
+  region text,
+  timezone text,
+  issued timestamp,
+  PRIMARY KEY (document_id, party));


### PR DESCRIPTION
Previously, we tried to store ENTIRE documents, including their
envelopes into Cassandra. This proved unmanageable. This change adds
merely the information required to run the Effective Rules job.